### PR TITLE
Add new project statuses

### DIFF
--- a/STATUSES.md
+++ b/STATUSES.md
@@ -7,10 +7,11 @@
 
 ## Modern Statuses
 
-| Status | Badge | Description |
-|--------|-------|-------------|
-| Maintenance | ![Maintenance](https://img.shields.io/badge/Maintenance-8A2BE2?style=for-the-badge&color=19e650)| The project is feature complete and remains maintained. |
-| Development | ![Development](https://img.shields.io/badge/Development-8A2BE2?style=for-the-badge&color=f5c907)| The project is actively being developed and maintained. |
+| Status      | Badge                                                                                            | Description                                             |
+| ----------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------- |
+| Maintenance | ![Maintenance](https://img.shields.io/badge/Maintenance-8A2BE2?style=for-the-badge&color=19e650) | The project is feature complete and remains maintained. |
+| Development | ![Development](https://img.shields.io/badge/Development-8A2BE2?style=for-the-badge&color=f5c907) | The project is actively being developed and maintained. |
+
 |
 | Deprecated | ![Deprecated](https://img.shields.io/badge/Deprecated-8A2BE2?style=for-the-badge&color=ff0000)| The project is deprecated and will no longer be maintained. Repository will be archived if not already. |
 

--- a/STATUSES.md
+++ b/STATUSES.md
@@ -12,7 +12,7 @@
 | Maintenance | ![Maintenance](https://img.shields.io/badge/Maintenance-8A2BE2?style=for-the-badge&color=19e650)| The project is feature complete and remains maintained. |
 | Development | ![Development](https://img.shields.io/badge/Development-8A2BE2?style=for-the-badge&color=f5c907)| The project is actively being developed and maintained. |
 |
-| Deprecated | ![Deprecated](https://img.shields.io/badge/Deprecated-8A2BE2?style=for-the-badge&color=ff0000)| The project is deprecated and will no longer be maintained. |
+| Deprecated | ![Deprecated](https://img.shields.io/badge/Deprecated-8A2BE2?style=for-the-badge&color=ff0000)| The project is deprecated and will no longer be maintained. Repository will be archived if not already. |
 
 ## Historic Statuses
 

--- a/STATUSES.md
+++ b/STATUSES.md
@@ -1,9 +1,22 @@
 # Statuses
 
 - [Statuses](#statuses)
-  - [Sunsetted/Decommissioned](#sunsetteddecommissioned)
+  - [Modern Statuses](#modern-statuses)
+  - [Historic Statuses](#historic-statuses)
+    - [Sunsetted/Decommissioned](#sunsetteddecommissioned)
 
-## Sunsetted/Decommissioned
+## Modern Statuses
+
+| Status | Badge | Description |
+|--------|-------|-------------|
+| Maintenance | ![Maintenance](https://img.shields.io/badge/Maintenance-8A2BE2?style=for-the-badge&color=19e650)| The project is feature complete and remains maintained. |
+| Development | ![Development](https://img.shields.io/badge/Development-8A2BE2?style=for-the-badge&color=f5c907)| The project is actively being developed and maintained. |
+|
+| Deprecated | ![Deprecated](https://img.shields.io/badge/Deprecated-8A2BE2?style=for-the-badge&color=ff0000)| The project is deprecated and will no longer be maintained. |
+
+## Historic Statuses
+
+### Sunsetted/Decommissioned
 
 > [!WARNING]
 > This project has been sunsetted and is no longer maintained.

--- a/STATUSES.md
+++ b/STATUSES.md
@@ -7,13 +7,11 @@
 
 ## Modern Statuses
 
-| Status      | Badge                                                                                            | Description                                             |
-| ----------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------- |
-| Maintenance | ![Maintenance](https://img.shields.io/badge/Maintenance-8A2BE2?style=for-the-badge&color=19e650) | The project is feature complete and remains maintained. |
-| Development | ![Development](https://img.shields.io/badge/Development-8A2BE2?style=for-the-badge&color=f5c907) | The project is actively being developed and maintained. |
-
-|
-| Deprecated | ![Deprecated](https://img.shields.io/badge/Deprecated-8A2BE2?style=for-the-badge&color=ff0000)| The project is deprecated and will no longer be maintained. Repository will be archived if not already. |
+| Status      | Badge                                                                                            | Description                                                                                             |
+| ----------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
+| Maintenance | ![Maintenance](https://img.shields.io/badge/Maintenance-8A2BE2?style=for-the-badge&color=19e650) | The project is feature complete and remains maintained.                                                 |
+| Development | ![Development](https://img.shields.io/badge/Development-8A2BE2?style=for-the-badge&color=f5c907) | The project is actively being developed and maintained.                                                 |
+| Deprecated  | ![Deprecated](https://img.shields.io/badge/Deprecated-8A2BE2?style=for-the-badge&color=ff0000)   | The project is deprecated and will no longer be maintained. Repository will be archived if not already. |
 
 ## Historic Statuses
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `STATUSES.md` file to reorganize and clarify project status categories. The changes introduce a new structure that separates modern statuses from historic ones and provides a table for modern statuses with badges and descriptions.

Reorganization of project statuses:

* Added a new section titled "Modern Statuses" with a table that includes three statuses: `Maintenance`, `Development`, and `Deprecated`, each with a badge and description.
* Renamed the "Sunsetted/Decommissioned" section to "Historic Statuses" and moved it under the new "Historic Statuses" heading.