### PR TITLE
Link Badge to Status

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,38 +18,38 @@ Statuses are used to indicate the current state of a project. They can be found 
 
 Projects are listed below with their current status. All projects are created by me, Jack Plowman. Forks are excluded from this list.
 
-| Project Name                                                                                      | Status | Notes |
-| ------------------------------------------------------------------------------------------------- | ------ | ----- |
-| [actions-status](https://github.com/JackPlowman/actions-status)                                   |        |       |
-| [aws-timing-scripts](https://github.com/JackPlowman/aws-timing-scripts)                           |        |       |
-| [create-repository-tasks](https://github.com/JackPlowman/create-repository-tasks)                 |        |       |
-| [DependabotTrigger](https://github.com/JackPlowman/DependabotTrigger)                             |        |       |
-| [development-environment](https://github.com/JackPlowman/development-environment)                 |        |       |
-| [development-ideas](https://github.com/JackPlowman/development-ideas)                             |        |       |
-| [github-pr-analyser](https://github.com/JackPlowman/github-pr-analyser)                           |        |       |
-| [github-stats](https://github.com/JackPlowman/github-stats)                                       |        |       |
-| [github-stats-analyser](https://github.com/JackPlowman/github-stats-analyser)                     |        |       |
-| [JackPlowman](https://github.com/JackPlowman/JackPlowman)                                         |        |       |
-| [project-links](https://github.com/JackPlowman/project-links)                                     |        |       |
-| [project-status-checker](https://github.com/JackPlowman/project-status-checker)                   |        |       |
-| [projects](https://github.com/JackPlowman/projects)                                               |        |       |
-| [python-practise](https://github.com/JackPlowman/python-practise)                                 |        |       |
-| [repo_standards_validator](https://github.com/JackPlowman/repo_standards_validator)               |        |       |
-| [repo-overseer](https://github.com/JackPlowman/repo-overseer)                                     |        |       |
-| [RepoOrchestrator](https://github.com/JackPlowman/RepoOrchestrator)                               |        |       |
-| [repository-template](https://github.com/JackPlowman/repository-template)                         |        |       |
-| [repository-visualiser](https://github.com/JackPlowman/repository-visualiser)                     |        |       |
-| [RepoSync](https://github.com/JackPlowman/RepoSync)                                               |        |       |
-| [reusable-workflows](https://github.com/JackPlowman/reusable-workflows)                           |        |       |
-| [screenshot_mailinator_email](https://github.com/JackPlowman/screenshot_mailinator_email)         |        |       |
-| [SlocCount](https://github.com/JackPlowman/SlocCount)                                             |        |       |
-| [source_scan](https://github.com/JackPlowman/source_scan)                                         |        |       |
-| [status-sentinel](https://github.com/JackPlowman/status-sentinel)                                 |        |       |
-| [tech-radar](https://github.com/JackPlowman/tech-radar)                                           |        |       |
-| [TechInsight](https://github.com/JackPlowman/TechInsight)                                         |        |       |
-| [TechScanner](https://github.com/JackPlowman/TechScanner)                                         |        |       |
-| [test-project-status-checker](https://github.com/JackPlowman/test-project-status-checker)         |        |       |
-| [windows-development-environment](https://github.com/JackPlowman/windows-development-environment) |        |       |
+| Project Name                                                                                      | Status                                                                                                                                                                                                | Notes |
+| ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| [actions-status](https://github.com/JackPlowman/actions-status)                                   |                                                                                                                                                                                                       |       |
+| [aws-timing-scripts](https://github.com/JackPlowman/aws-timing-scripts)                           |                                                                                                                                                                                                       |       |
+| [create-repository-tasks](https://github.com/JackPlowman/create-repository-tasks)                 |                                                                                                                                                                                                       |       |
+| [DependabotTrigger](https://github.com/JackPlowman/DependabotTrigger)                             |                                                                                                                                                                                                       |       |
+| [development-environment](https://github.com/JackPlowman/development-environment)                 |                                                                                                                                                                                                       |       |
+| [development-ideas](https://github.com/JackPlowman/development-ideas)                             |                                                                                                                                                                                                       |       |
+| [github-pr-analyser](https://github.com/JackPlowman/github-pr-analyser)                           |                                                                                                                                                                                                       |       |
+| [github-stats](https://github.com/JackPlowman/github-stats)                                       |                                                                                                                                                                                                       |       |
+| [github-stats-analyser](https://github.com/JackPlowman/github-stats-analyser)                     | ![Maintenance](https://img.shields.io/badge/Maintenance-8A2BE2?style=for-the-badge&color=19e650&link=https%3A%2F%2Fgithub.com%2FJackPlowman%2Fprojects%2Fblob%2Fmain%2FSTATUSES.md%23modern-statuses) |       |
+| [JackPlowman](https://github.com/JackPlowman/JackPlowman)                                         |                                                                                                                                                                                                       |       |
+| [project-links](https://github.com/JackPlowman/project-links)                                     |                                                                                                                                                                                                       |       |
+| [project-status-checker](https://github.com/JackPlowman/project-status-checker)                   |                                                                                                                                                                                                       |       |
+| [projects](https://github.com/JackPlowman/projects)                                               |                                                                                                                                                                                                       |       |
+| [python-practise](https://github.com/JackPlowman/python-practise)                                 |                                                                                                                                                                                                       |       |
+| [repo_standards_validator](https://github.com/JackPlowman/repo_standards_validator)               |                                                                                                                                                                                                       |       |
+| [repo-overseer](https://github.com/JackPlowman/repo-overseer)                                     |                                                                                                                                                                                                       |       |
+| [RepoOrchestrator](https://github.com/JackPlowman/RepoOrchestrator)                               |                                                                                                                                                                                                       |       |
+| [repository-template](https://github.com/JackPlowman/repository-template)                         |                                                                                                                                                                                                       |       |
+| [repository-visualiser](https://github.com/JackPlowman/repository-visualiser)                     |                                                                                                                                                                                                       |       |
+| [RepoSync](https://github.com/JackPlowman/RepoSync)                                               |                                                                                                                                                                                                       |       |
+| [reusable-workflows](https://github.com/JackPlowman/reusable-workflows)                           |                                                                                                                                                                                                       |       |
+| [screenshot_mailinator_email](https://github.com/JackPlowman/screenshot_mailinator_email)         |                                                                                                                                                                                                       |       |
+| [SlocCount](https://github.com/JackPlowman/SlocCount)                                             |                                                                                                                                                                                                       |       |
+| [source_scan](https://github.com/JackPlowman/source_scan)                                         |                                                                                                                                                                                                       |       |
+| [status-sentinel](https://github.com/JackPlowman/status-sentinel)                                 |                                                                                                                                                                                                       |       |
+| [tech-radar](https://github.com/JackPlowman/tech-radar)                                           |                                                                                                                                                                                                       |       |
+| [TechInsight](https://github.com/JackPlowman/TechInsight)                                         |                                                                                                                                                                                                       |       |
+| [TechScanner](https://github.com/JackPlowman/TechScanner)                                         |                                                                                                                                                                                                       |       |
+| [test-project-status-checker](https://github.com/JackPlowman/test-project-status-checker)         |                                                                                                                                                                                                       |       |
+| [windows-development-environment](https://github.com/JackPlowman/windows-development-environment) |                                                                                                                                                                                                       |       |
 
 ## Contributing
 

--- a/STATUSES.md
+++ b/STATUSES.md
@@ -7,11 +7,11 @@
 
 ## Modern Statuses
 
-| Status      | Badge                                                                                            | Description                                                                                             |
-| ----------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
-| Maintenance | ![Maintenance](https://img.shields.io/badge/Maintenance-8A2BE2?style=for-the-badge&color=19e650) | The project is feature complete and remains maintained.                                                 |
-| Development | ![Development](https://img.shields.io/badge/Development-8A2BE2?style=for-the-badge&color=f5c907) | The project is actively being developed and maintained.                                                 |
-| Deprecated  | ![Deprecated](https://img.shields.io/badge/Deprecated-8A2BE2?style=for-the-badge&color=ff0000)   | The project is deprecated and will no longer be maintained. Repository will be archived if not already. |
+| Status      | Badge                                                                                                                                                                                                 | Description                                                                                             |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Maintenance | ![Maintenance](https://img.shields.io/badge/Maintenance-8A2BE2?style=for-the-badge&color=19e650&link=https%3A%2F%2Fgithub.com%2FJackPlowman%2Fprojects%2Fblob%2Fmain%2FSTATUSES.md%23modern-statuses) | The project is feature complete and remains maintained.                                                 |
+| Development | ![Development](https://img.shields.io/badge/Development-8A2BE2?style=for-the-badge&color=f5c907&link=https%3A%2F%2Fgithub.com%2FJackPlowman%2Fprojects%2Fblob%2Fmain%2FSTATUSES.md%23modern-statuses) | The project is actively being developed and maintained.                                                 |
+| Deprecated  | ![Deprecated](https://img.shields.io/badge/Deprecated-8A2BE2?style=for-the-badge&color=ff0000&link=https%3A%2F%2Fgithub.com%2FJackPlowman%2Fprojects%2Fblob%2Fmain%2FSTATUSES.md%23modern-statuses)   | The project is deprecated and will no longer be maintained. Repository will be archived if not already. |
 
 ## Historic Statuses
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `README.md` and `STATUSES.md` files to improve the clarity and functionality of project status badges. The most important changes include adding clickable links to status badges for better navigation and updating the table formatting for consistency.

### Updates to project status badges:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31-R31): Added a clickable "Maintenance" badge for the `github-stats-analyser` project, linking to the relevant section in `STATUSES.md`. This improves usability by allowing users to quickly access detailed status descriptions.
* [`STATUSES.md`](diffhunk://#diff-d7e8611a894fc6c22d6f911179e51f1705a728a93b5f7993016285acb7b3d003L11-R14): Updated all modern status badges (`Maintenance`, `Development`, `Deprecated`) to include clickable links pointing to their respective descriptions within the same file. This enhances navigation and makes the statuses more interactive.

### Table formatting improvements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22-R22): Adjusted the table formatting for the "Status" column to ensure alignment and consistency across all rows.