### PR TITLE
Update Badges and Colours

### DIFF
--- a/STATUSES.md
+++ b/STATUSES.md
@@ -9,8 +9,8 @@
 
 | Status      | Badge                                                                                            | Description                                                                                             |
 | ----------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
-| Maintenance | ![Maintenance](https://img.shields.io/badge/Maintenance-8A2BE2?style=for-the-badge&color=19e650) | The project is feature complete and remains maintained.                                                 |
-| Development | ![Development](https://img.shields.io/badge/Development-8A2BE2?style=for-the-badge&color=f5c907) | The project is actively being developed and maintained.                                                 |
+| Development | ![Active Development](https://img.shields.io/badge/Development-8A2BE2?style=for-the-badge&color=19e650) | The project is actively being developed and maintained.
+| Maintenance | ![Maintenance](https://img.shields.io/badge/Maintenance-8A2BE2?style=for-the-badge&color=1803ff) | The project is feature complete and remains maintained.                                                 |
 | Deprecated  | ![Deprecated](https://img.shields.io/badge/Deprecated-8A2BE2?style=for-the-badge&color=ff0000)   | The project is deprecated and will no longer be maintained. Repository will be archived if not already. |
 
 ## Historic Statuses

--- a/STATUSES.md
+++ b/STATUSES.md
@@ -7,11 +7,11 @@
 
 ## Modern Statuses
 
-| Status      | Badge                                                                                            | Description                                                                                             |
-| ----------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
-| Development | ![Active Development](https://img.shields.io/badge/Development-8A2BE2?style=for-the-badge&color=19e650) | The project is actively being developed and maintained.
-| Maintenance | ![Maintenance](https://img.shields.io/badge/Maintenance-8A2BE2?style=for-the-badge&color=1803ff) | The project is feature complete and remains maintained.                                                 |
-| Deprecated  | ![Deprecated](https://img.shields.io/badge/Deprecated-8A2BE2?style=for-the-badge&color=ff0000)   | The project is deprecated and will no longer be maintained. Repository will be archived if not already. |
+| Status      | Badge                                                                                                   | Description                                                                                             |
+| ----------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Development | ![Active Development](https://img.shields.io/badge/Development-8A2BE2?style=for-the-badge&color=19e650) | The project is actively being developed and maintained.                                                 |
+| Maintenance | ![Maintenance](https://img.shields.io/badge/Maintenance-8A2BE2?style=for-the-badge&color=1803ff)        | The project is feature complete and remains maintained.                                                 |
+| Deprecated  | ![Deprecated](https://img.shields.io/badge/Deprecated-8A2BE2?style=for-the-badge&color=ff0000)          | The project is deprecated and will no longer be maintained. Repository will be archived if not already. |
 
 ## Historic Statuses
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a minor update to the `STATUSES.md` file to improve clarity and consistency in the status badges.

* Updated the `Development` badge label to "Active Development" for better clarity and changed its color to match the previous `Maintenance` badge color. (`[STATUSES.mdL12-R13](diffhunk://#diff-d7e8611a894fc6c22d6f911179e51f1705a728a93b5f7993016285acb7b3d003L12-R13)`)
* Adjusted the `Maintenance` badge color to a new shade of blue for improved visual distinction. (`[STATUSES.mdL12-R13](diffhunk://#diff-d7e8611a894fc6c22d6f911179e51f1705a728a93b5f7993016285acb7b3d003L12-R13)`)