### PR TITLE
Migrate to Reusable CodeQL Workflow

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -43,21 +43,14 @@ jobs:
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 
-  run-codeql-analysis:
+  codeql-checks:
     name: CodeQL Analysis
-    runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
-        with:
-          languages: actions
-          queries: security-and-quality
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
+    strategy:
+      matrix:
+        language: [actions]
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@75ceb782a5815a98162de1321c852df74830a493 # v2025.05.24.01
+    with:
+      language: ${{ matrix.language }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the CodeQL analysis workflow in `.github/workflows/code-checks.yml` to use a reusable workflow, simplifying the configuration and improving maintainability.

### Workflow improvements:
* Renamed the job from `run-codeql-analysis` to `codeql-checks` for better clarity.
* Updated the workflow to use a reusable workflow from `JackPlowman/reusable-workflows` instead of directly specifying steps, reducing redundancy and making updates easier.
* Added a matrix strategy for the `language` parameter, enabling more flexibility in specifying analysis targets.
* Adjusted permissions to explicitly set `contents: read` and `security-events: write`, enhancing security by limiting access to only what is necessary.