### PR TITLE
Add projects to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Projects are listed below with their current status. All projects are created by
 | [DependabotTrigger](https://github.com/JackPlowman/DependabotTrigger)                             |                                                                                                  |       |
 | [development-environment](https://github.com/JackPlowman/development-environment)                 |                                                                                                  |       |
 | [development-ideas](https://github.com/JackPlowman/development-ideas)                             |                                                                                                  |       |
+| [gitdash](https://github.com/JackPlowman/gitdash)                           |                                                                                                  |       |
 | [github-pr-analyser](https://github.com/JackPlowman/github-pr-analyser)                           |                                                                                                  |       |
 | [github-stats](https://github.com/JackPlowman/github-stats)                                       |                                                                                                  |       |
 | [github-stats-analyser](https://github.com/JackPlowman/github-stats-analyser)                     | ![Maintenance](https://img.shields.io/badge/Maintenance-8A2BE2?style=for-the-badge&color=19e650) |       |
@@ -50,6 +51,7 @@ Projects are listed below with their current status. All projects are created by
 | [TechInsight](https://github.com/JackPlowman/TechInsight)                                         |                                                                                                  |       |
 | [TechScanner](https://github.com/JackPlowman/TechScanner)                                         |                                                                                                  |       |
 | [test-project-status-checker](https://github.com/JackPlowman/test-project-status-checker)         |                                                                                                  |       |
+| [useful-commands](https://github.com/JackPlowman/useful-commands) | ![Maintenance](https://img.shields.io/badge/Maintenance-8A2BE2?style=for-the-badge&color=19e650) |
 | [windows-development-environment](https://github.com/JackPlowman/windows-development-environment) | ![Maintenance](https://img.shields.io/badge/Maintenance-8A2BE2?style=for-the-badge&color=19e650) |       |
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Projects are listed below with their current status. All projects are created by
 | [DependabotTrigger](https://github.com/JackPlowman/DependabotTrigger)                             |                                                                                                  |       |
 | [development-environment](https://github.com/JackPlowman/development-environment)                 |                                                                                                  |       |
 | [development-ideas](https://github.com/JackPlowman/development-ideas)                             |                                                                                                  |       |
-| [gitdash](https://github.com/JackPlowman/gitdash)                           |                                                                                                  |       |
+| [gitdash](https://github.com/JackPlowman/gitdash)                                                 |                                                                                                  |       |
 | [github-pr-analyser](https://github.com/JackPlowman/github-pr-analyser)                           |                                                                                                  |       |
 | [github-stats](https://github.com/JackPlowman/github-stats)                                       |                                                                                                  |       |
 | [github-stats-analyser](https://github.com/JackPlowman/github-stats-analyser)                     | ![Maintenance](https://img.shields.io/badge/Maintenance-8A2BE2?style=for-the-badge&color=19e650) |       |
@@ -51,7 +51,7 @@ Projects are listed below with their current status. All projects are created by
 | [TechInsight](https://github.com/JackPlowman/TechInsight)                                         |                                                                                                  |       |
 | [TechScanner](https://github.com/JackPlowman/TechScanner)                                         |                                                                                                  |       |
 | [test-project-status-checker](https://github.com/JackPlowman/test-project-status-checker)         |                                                                                                  |       |
-| [useful-commands](https://github.com/JackPlowman/useful-commands) | ![Maintenance](https://img.shields.io/badge/Maintenance-8A2BE2?style=for-the-badge&color=19e650) |
+| [useful-commands](https://github.com/JackPlowman/useful-commands)                                 | ![Maintenance](https://img.shields.io/badge/Maintenance-8A2BE2?style=for-the-badge&color=19e650) |
 | [windows-development-environment](https://github.com/JackPlowman/windows-development-environment) | ![Maintenance](https://img.shields.io/badge/Maintenance-8A2BE2?style=for-the-badge&color=19e650) |       |
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ Statuses are used to indicate the current state of a project. They can be found 
 Projects are listed below with their current status. All projects are created by me, Jack Plowman. Forks are excluded from this list.
 
 | Project Name                                                                                      | Status                                                                                           | Notes |
-| ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | ----- | --- |
+| ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | ----- |
 | [actions-status](https://github.com/JackPlowman/actions-status)                                   |                                                                                                  |       |
 | [aws-timing-scripts](https://github.com/JackPlowman/aws-timing-scripts)                           |                                                                                                  |       |
 | [create-repository-tasks](https://github.com/JackPlowman/create-repository-tasks)                 |                                                                                                  |       |
 | [DependabotTrigger](https://github.com/JackPlowman/DependabotTrigger)                             |                                                                                                  |       |
 | [development-environment](https://github.com/JackPlowman/development-environment)                 |                                                                                                  |       |
 | [development-ideas](https://github.com/JackPlowman/development-ideas)                             |                                                                                                  |       |
-| [gitdash](https://github.com/JackPlowman/gitdash)                                                 |                                                                                                  |       |     |
+| [gitdash](https://github.com/JackPlowman/gitdash)                                                 |                                                                                                  |       |
 | [github-pr-analyser](https://github.com/JackPlowman/github-pr-analyser)                           |                                                                                                  |       |
 | [github-stats](https://github.com/JackPlowman/github-stats)                                       |                                                                                                  |       |
 | [github-stats-analyser](https://github.com/JackPlowman/github-stats-analyser)                     | ![Maintenance](https://img.shields.io/badge/Maintenance-8A2BE2?style=for-the-badge&color=19e650) |       |

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ Statuses are used to indicate the current state of a project. They can be found 
 Projects are listed below with their current status. All projects are created by me, Jack Plowman. Forks are excluded from this list.
 
 | Project Name                                                                                      | Status                                                                                           | Notes |
-| ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | ----- |
+| ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | ----- | --- |
 | [actions-status](https://github.com/JackPlowman/actions-status)                                   |                                                                                                  |       |
 | [aws-timing-scripts](https://github.com/JackPlowman/aws-timing-scripts)                           |                                                                                                  |       |
 | [create-repository-tasks](https://github.com/JackPlowman/create-repository-tasks)                 |                                                                                                  |       |
 | [DependabotTrigger](https://github.com/JackPlowman/DependabotTrigger)                             |                                                                                                  |       |
 | [development-environment](https://github.com/JackPlowman/development-environment)                 |                                                                                                  |       |
 | [development-ideas](https://github.com/JackPlowman/development-ideas)                             |                                                                                                  |       |
-| [gitdash](https://github.com/JackPlowman/gitdash)                                                 |                                                                                                  |       |
+| [gitdash](https://github.com/JackPlowman/gitdash)                                                 |                                                                                                  |       |     |
 | [github-pr-analyser](https://github.com/JackPlowman/github-pr-analyser)                           |                                                                                                  |       |
 | [github-stats](https://github.com/JackPlowman/github-stats)                                       |                                                                                                  |       |
 | [github-stats-analyser](https://github.com/JackPlowman/github-stats-analyser)                     | ![Maintenance](https://img.shields.io/badge/Maintenance-8A2BE2?style=for-the-badge&color=19e650) |       |

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Projects are listed below with their current status. All projects are created by
 | [TechInsight](https://github.com/JackPlowman/TechInsight)                                         |                                                                                                  |       |
 | [TechScanner](https://github.com/JackPlowman/TechScanner)                                         |                                                                                                  |       |
 | [test-project-status-checker](https://github.com/JackPlowman/test-project-status-checker)         |                                                                                                  |       |
-| [useful-commands](https://github.com/JackPlowman/useful-commands)                                 | ![Maintenance](https://img.shields.io/badge/Maintenance-8A2BE2?style=for-the-badge&color=19e650) |
+| [useful-commands](https://github.com/JackPlowman/useful-commands)                                 | ![Maintenance](https://img.shields.io/badge/Maintenance-8A2BE2?style=for-the-badge&color=19e650) |       |
 | [windows-development-environment](https://github.com/JackPlowman/windows-development-environment) | ![Maintenance](https://img.shields.io/badge/Maintenance-8A2BE2?style=for-the-badge&color=19e650) |       |
 
 ## Contributing


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `README.md` file to include two additional projects in the list of repositories. These changes ensure that the documentation reflects the latest project additions.

Updates to the project list:

* Added `gitdash` to the list of projects.
* Added `useful-commands` to the list of projects, along with a maintenance badge indicating its status.