### PR TITLE
Add travel-map project status

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Projects are listed below with their current status. All projects are created by
 | [source_scan](https://github.com/JackPlowman/source_scan)                                         | ![Maintenance](https://img.shields.io/badge/Maintenance-8A2BE2?style=for-the-badge&color=19e650) |       |
 | [status-sentinel](https://github.com/JackPlowman/status-sentinel)                                 |                                                                                                  |       |
 | [tech-radar](https://github.com/JackPlowman/tech-radar)                                           |                                                                                                  |       |
-| [travel-map](https://github.com/JackPlowman/travel-map)                                           |                                                                                                  |       |
+| [travel-map](https://github.com/JackPlowman/travel-map)                                           | ![Development](https://img.shields.io/badge/Development-8A2BE2?style=for-the-badge&color=ff9500) |       |
 | [TechInsight](https://github.com/JackPlowman/TechInsight)                                         |                                                                                                  |       |
 | [TechScanner](https://github.com/JackPlowman/TechScanner)                                         |                                                                                                  |       |
 | [test-project-status-checker](https://github.com/JackPlowman/test-project-status-checker)         |                                                                                                  |       |


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `README.md` file to include a status badge for the `travel-map` project, indicating its current development status.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L50-R50): Added a "Development" status badge for the `travel-map` project to reflect its current status.