### PR TITLE
Add RepoSync project status

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Projects are listed below with their current status. All projects are created by
 | [RepoOrchestrator](https://github.com/JackPlowman/RepoOrchestrator)                               |                                                                                                  |       |
 | [repository-template](https://github.com/JackPlowman/repository-template)                         |                                                                                                  |       |
 | [repository-visualiser](https://github.com/JackPlowman/repository-visualiser)                     |                                                                                                  |       |
-| [RepoSync](https://github.com/JackPlowman/RepoSync)                                               |                                                                                                  |       |
+| [RepoSync](https://github.com/JackPlowman/RepoSync)                                               | ![Maintenance](https://img.shields.io/badge/Maintenance-8A2BE2?style=for-the-badge&color=19e650) |       |
 | [reusable-workflows](https://github.com/JackPlowman/reusable-workflows)                           |                                                                                                  |       |
 | [screenshot_mailinator_email](https://github.com/JackPlowman/screenshot_mailinator_email)         | ![Maintenance](https://img.shields.io/badge/Maintenance-8A2BE2?style=for-the-badge&color=19e650) |       |
 | [SlocCount](https://github.com/JackPlowman/SlocCount)                                             | ![Development](https://img.shields.io/badge/Development-8A2BE2?style=for-the-badge&color=ff9500) |       |


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `README.md` file to include a maintenance status badge for the `RepoSync` project.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L43-R43): Added a maintenance status badge to the `RepoSync` project entry, indicating its current status.