### PR TITLE
Add test-project-status-checker project status

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Projects are listed below with their current status. All projects are created by
 | [travel-map](https://github.com/JackPlowman/travel-map)                                           | ![Maintenance](https://img.shields.io/badge/Maintenance-8A2BE2?style=for-the-badge&color=19e650) |       |
 | [TechInsight](https://github.com/JackPlowman/TechInsight)                                         |                                                                                                  |       |
 | [TechScanner](https://github.com/JackPlowman/TechScanner)                                         |                                                                                                  |       |
-| [test-project-status-checker](https://github.com/JackPlowman/test-project-status-checker)         |                                                                                                  |       |
+| [test-project-status-checker](https://github.com/JackPlowman/test-project-status-checker)         | ![Maintenance](https://img.shields.io/badge/Maintenance-8A2BE2?style=for-the-badge&color=19e650) |       |
 | [useful-commands](https://github.com/JackPlowman/useful-commands)                                 | ![Maintenance](https://img.shields.io/badge/Maintenance-8A2BE2?style=for-the-badge&color=19e650) |       |
 | [windows-development-environment](https://github.com/JackPlowman/windows-development-environment) | ![Maintenance](https://img.shields.io/badge/Maintenance-8A2BE2?style=for-the-badge&color=19e650) |       |
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `README.md` file to include a maintenance status badge for the `test-project-status-checker` project.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L53-R53): Added a maintenance status badge to the `test-project-status-checker` project entry, aligning it with the format used for other projects.