### PR TITLE
Add repo-overseer project status

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Projects are listed below with their current status. All projects are created by
 | [projects](https://github.com/JackPlowman/projects)                                               |                                                                                                  |       |
 | [python-practise](https://github.com/JackPlowman/python-practise)                                 |                                                                                                  |       |
 | [repo_standards_validator](https://github.com/JackPlowman/repo_standards_validator)               |                                                                                                  |       |
-| [repo-overseer](https://github.com/JackPlowman/repo-overseer)                                     |                                                                                                  |       |
+| [repo-overseer](https://github.com/JackPlowman/repo-overseer)                                     | ![Maintenance](https://img.shields.io/badge/Maintenance-8A2BE2?style=for-the-badge&color=19e650) |       |
 | [RepoOrchestrator](https://github.com/JackPlowman/RepoOrchestrator)                               |                                                                                                  |       |
 | [repository-template](https://github.com/JackPlowman/repository-template)                         | ![Maintenance](https://img.shields.io/badge/Maintenance-8A2BE2?style=for-the-badge&color=19e650) |       |
 | [repository-visualiser](https://github.com/JackPlowman/repository-visualiser)                     |                                                                                                  |       |


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `README.md` file to include a maintenance status badge for the `repo-overseer` project, making the project's status more transparent.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L39-R39): Added a maintenance status badge to the `repo-overseer` project entry in the projects list.