### PR TITLE
Update License to Licence

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -25,7 +25,7 @@ markdown:
               [
                 "docs/*.md",
                 "*.md",
-                "LICENSE",
+                "LICENCE",
                 ".github/pull_request_template.md",
               ]
 python:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the file pattern for documentation-related labeling in the `.github/other-configurations/labeller.yml` configuration file. The change corrects the spelling of the license file to match the repository's naming convention.

* Documentation labeling configuration: Changed the file pattern from `"LICENSE"` to `"LICENCE"` in the `markdown:` section to ensure correct labeling of the license file.