### PR TITLE
Remove SuperLinter

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,6 @@ updates:
         patterns:
           - "*"
         exclude-patterns:
-          - "super-linter/super-linter"
           - "JackPlowman/reusable-workflows"
         update-types:
           - "patch"

--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -12,11 +12,7 @@ dependencies:
 configurations:
   - any:
       - changed-files:
-          - any-glob-to-any-file:
-              [
-                ".github/other-configurations/*",
-                ".github/super-linter-configurations/*",
-              ]
+          - any-glob-to-any-file: [".github/other-configurations/*"]
 # Language
 markdown:
   - any:

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -16,34 +16,6 @@ env:
   FORCE_COLOR: 1
 
 jobs:
-  check-code-quality:
-    name: Check Code Quality
-    runs-on: ubuntu-latest
-    permissions:
-      statuses: write
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Lint Code Base
-        uses: super-linter/super-linter@12150456a73e248bdc94d0794898f94e23127c88 # v7.4.0
-        env:
-          VALIDATE_ALL_CODEBASE: true
-          DEFAULT_BRANCH: main
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          LINTER_RULES_PATH: .github/super-linter-configurations
-          YAML_ERROR_ON_WARNING: true
-          VALIDATE_EDITORCONFIG: false
-          VALIDATE_GIT_COMMITLINT: false
-          VALIDATE_PYTHON_BLACK: false
-          VALIDATE_PYTHON_FLAKE8: false
-          VALIDATE_PYTHON_ISORT: false
-          VALIDATE_PYTHON_MYPY: false
-          VALIDATE_PYTHON_PYLINT: false
-          VALIDATE_PYTHON_RUFF: false
-
   common-code-checks:
     name: Common Code Checks
     permissions:


### PR DESCRIPTION
# Pull Request

## Description

This pull request removes the use of Super Linter from the repository's CI/CD workflows and configuration files. The main changes include deleting the Super Linter job from the code checks workflow, cleaning up related configuration and exclusion patterns, and updating the labeller configuration to reflect these removals.

**Super Linter removal:**

* Deleted the entire `check-code-quality` job from `.github/workflows/code-checks.yml`, which previously ran Super Linter to validate code quality.
* Removed the exclusion pattern for `super-linter/super-linter` in the dependabot configuration file `.github/dependabot.yml`.

**Configuration updates:**

* Updated the labeller configuration in `.github/other-configurations/labeller.yml` to remove references to Super Linter configuration files.